### PR TITLE
feat: speed-up remote recipe check-outs

### DIFF
--- a/src/repror/internals/commands.py
+++ b/src/repror/internals/commands.py
@@ -33,7 +33,7 @@ class StreamType(Enum):
 
 def run_streaming_command(
     command: list[str],
-    cwd: Optional[list[str]] = None,
+    cwd: Optional[str | bytes | os.PathLike[str] | os.PathLike[bytes]] = None,
     env: Optional[list[str]] = None,
     stream_type: StreamType = StreamType.STDERR,
 ) -> int:

--- a/src/repror/internals/config.py
+++ b/src/repror/internals/config.py
@@ -55,31 +55,32 @@ def save_config(data: ConfigYaml, config_path: str = "config.yaml"):
 def load_all_recipes(config_path: str = "config.yaml") -> list[RecipeDB | RemoteRecipe]:
     config = load_config(config_path)
     recipes = []
-    for repo in config.repositories:
-        for recipe in repo.recipes:
-            stored_recipe = get_recipe(repo.url, recipe.path, repo.rev)
-            if not stored_recipe:
-                logger.debug(
-                    f"Recipe {recipe.path} not found in the database, adding it"
-                )
-                with tempfile.TemporaryDirectory() as clone_dir:
+    with tempfile.TemporaryDirectory() as clone_dir:
+        for repo in config.repositories:
+            for recipe in repo.recipes:
+                stored_recipe = get_recipe(repo.url, recipe.path, repo.rev)
+                if not stored_recipe:
+                    print(f"Recipe {recipe.path} not found in the database, adding it")
+                    logger.debug(
+                        f"Recipe {recipe.path} not found in the database, adding it"
+                    )
                     remote_config, raw_config = load_remote_recipe_config(
                         repo.url, repo.rev, recipe.path, Path(clone_dir)
                     )
-                recipe_name = get_recipe_name(remote_config)
-                recipe_content_hash = recipe_files_hash(Path(recipe.path).parent)
-                stored_recipe = RemoteRecipe(
-                    name=recipe_name,
-                    url=repo.url,
-                    path=str(recipe.path),
-                    raw_config=raw_config,
-                    rev=repo.rev,
-                    content_hash=recipe_content_hash,
-                )
-                save(stored_recipe)
-            else:
-                logger.debug(f"Recipe {recipe.path} found in the database")
-            recipes.append(stored_recipe)
+                    recipe_name = get_recipe_name(remote_config)
+                    recipe_content_hash = recipe_files_hash(Path(recipe.path).parent)
+                    stored_recipe = RemoteRecipe(
+                        name=recipe_name,
+                        url=repo.url,
+                        path=str(recipe.path),
+                        raw_config=raw_config,
+                        rev=repo.rev,
+                        content_hash=recipe_content_hash,
+                    )
+                    save(stored_recipe)
+                else:
+                    logger.debug(f"Recipe {recipe.path} found in the database")
+                recipes.append(stored_recipe)
 
     for local in config.local:
         local_config = load_recipe_config(local.path)

--- a/src/repror/internals/config.py
+++ b/src/repror/internals/config.py
@@ -60,7 +60,6 @@ def load_all_recipes(config_path: str = "config.yaml") -> list[RecipeDB | Remote
             for recipe in repo.recipes:
                 stored_recipe = get_recipe(repo.url, recipe.path, repo.rev)
                 if not stored_recipe:
-                    print(f"Recipe {recipe.path} not found in the database, adding it")
                     logger.debug(
                         f"Recipe {recipe.path} not found in the database, adding it"
                     )

--- a/src/repror/internals/db.py
+++ b/src/repror/internals/db.py
@@ -168,8 +168,9 @@ class RemoteRecipe(Recipe, SQLModel, table=True):
     def local_path(self) -> Generator[str, None, None]:
         with tempfile.TemporaryDirectory() as tmp_dir:
             clone_dir = Path(tmp_dir)
-            repo_dir = clone_remote_recipe(self.url, self.rev, clone_dir)
-            recipe_path = repo_dir / Path(self.path).parent
+            path_to_recipe_folder = Path(self.path).parent
+            repo_dir = clone_remote_recipe(self.url, self.rev, clone_dir, path_to_recipe_folder)
+            recipe_path = repo_dir / path_to_recipe_folder
             yield str(recipe_path)
 
 

--- a/src/repror/internals/git.py
+++ b/src/repror/internals/git.py
@@ -119,6 +119,24 @@ def clone_repo(repo_url, clone_dir) -> int:
         ["git", "clone", repo_url, str(clone_dir)], stream_type=StreamType.STDOUT
     )
 
+def clone_no_checkout(repo_url: str, clone_dir: Path) -> int:
+    """Clone a repository without checking out the files."""
+    return run_streaming_command(
+        ["git", "clone", "--filter=blob:none", "--no-checkout", repo_url, str(clone_dir)], stream_type=StreamType.STDOUT
+    )
+
+def sparse_checkout_init(clone_dir: Path) -> int:
+    """Initialize sparse checkout."""
+    return run_streaming_command(
+        ["git", "sparse-checkout", "init", "--cone"], cwd=str(clone_dir), stream_type=StreamType.STDOUT
+    )
+
+
+def sparse_checkout_set(clone_dir: Path, sparse_path: Path) -> int:
+    """"Sparse checkout the repository."""
+    return run_streaming_command(
+        ["git", "sparse-checkout", "set", str(sparse_path)], cwd=str(clone_dir), stream_type=StreamType.STDOUT
+    )
 
 def fetch_changes(clone_dir: Path) -> CompletedProcess:
     """Fetch latest changes from remote."""

--- a/src/repror/internals/recipe.py
+++ b/src/repror/internals/recipe.py
@@ -5,14 +5,23 @@ import yaml
 from repror.internals import git
 
 
-def clone_remote_recipe(url: str, rev: str, clone_dir: Path) -> Path:
+def clone_remote_recipe(url: str, rev: str, clone_dir: Path, path_to_recipe_folder: Path) -> Path:
     repo_dir = clone_dir.joinpath(
         url.replace(".git", "").replace("/", "").replace("https:", "")
     )
 
+    # Clone without big files and no checkout,
+    # so that it is a lot faster
     if not repo_dir.exists():
-        git.clone_repo(url, repo_dir)
+        git.clone_no_checkout(url, repo_dir)
 
+    # Check if we have the sparsely checked out folder
+    # Even if we have the repo, we might not have the folder
+    if not repo_dir.joinpath(path_to_recipe_folder).exists():
+        git.sparse_checkout_init(repo_dir)
+        git.sparse_checkout_set(repo_dir, path_to_recipe_folder)
+
+    # Checkout the commit
     git.checkout_branch_or_commit(repo_dir, rev)
     return repo_dir
 
@@ -20,7 +29,7 @@ def clone_remote_recipe(url: str, rev: str, clone_dir: Path) -> Path:
 def load_remote_recipe_config(
     url: str, rev: str, path: str, clone_dir: Path
 ) -> tuple[dict, str]:
-    cloned_recipe = clone_remote_recipe(url, rev, clone_dir)
+    cloned_recipe = clone_remote_recipe(url, rev, clone_dir, path_to_recipe_folder=Path(path).parent)
 
     recipe_path = cloned_recipe / path
     config = load_recipe_config(recipe_path)


### PR DESCRIPTION
This should significantly speed-up remote checkouts for the repositories by:

* Re-using the same temporary file location when cloning the repo
* Not checking out by default, using sparse checkouts for the recipes locations

We could speed this up further by aggregating the sparse-locations and setting them in one go, but this should already help quite a bit.