### PR TITLE
feat: aggregate Build/Rebuilds for use in statistics

### DIFF
--- a/src/repror/internals/db.py
+++ b/src/repror/internals/db.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 import hashlib
@@ -17,6 +18,7 @@ from sqlmodel import (
     SQLModel,
     and_,
     create_engine,
+    distinct,
     or_,
     select,
     Session as SqlModelSession,
@@ -88,6 +90,13 @@ def setup_engine(in_memory: bool = False):
     )
     create_db_and_tables()
 
+def setup_local_db() -> sessionmaker[SqlModelSession]:
+    """Setup in-mmory database for testing."""
+    engine = create_engine("sqlite:///:memory:", echo=True)
+    session = sessionmaker(class_=SqlModelSession, expire_on_commit=False)
+    session.configure(bind=engine)
+    SQLModel.metadata.create_all(engine)
+    return session
 
 def __set_engine() -> None:
     global engine
@@ -301,3 +310,49 @@ def get_recipe(url: str, path: str | Path, rev: str) -> Optional[RemoteRecipe]:
         )
 
         return session.exec(recipe_query).first()
+
+
+def get_total_unique_recipes(session: Optional[SqlModelSession] = None) -> int:
+    """Query to get the total number of unique recipes"""
+    with get_session() if not session else session as session:
+        return session.exec(select(func.count(distinct(RemoteRecipe.name)))).one()
+
+@dataclass
+class SuccessfulBuildsAndRebuilds:
+    builds: int
+    rebuilds: int
+
+def get_total_successful_builds_and_rebuilds(timestamp: datetime, session: Optional[SqlModelSession] = None) -> SuccessfulBuildsAndRebuilds:
+    """Query to get the total number of successful builds and rebuilds before the given timestamp."""
+    with get_session() if not session else session as session:
+        # Subquery to find the latest build for each unique recipe_name before the given timestamp
+        subquery = (
+            select(
+                Build.id,
+                Build.recipe_name,
+            )
+            .where(col(Build.timestamp) <= timestamp)
+            .group_by(Build.recipe_name)
+            .subquery()
+        )
+
+        # Query to get the total number of successful builds
+        successful_builds_query = (
+            select(func.count(col(Build.id)))
+            .join(subquery, (col(Build.id) == subquery.c.id))
+            .where(Build.state == BuildState.SUCCESS)
+        )
+
+        # Query to get the total number of successful rebuilds for the selected builds
+        successful_rebuilds_query = (
+            select(func.count(col(Rebuild.id)))
+            .where(
+                col(Rebuild.build_id).in_(subquery),
+                Rebuild.state == BuildState.SUCCESS
+            )
+        )
+
+        # Execute the queries and count the results
+        successful_builds_count = session.exec(successful_builds_query).one()
+        successful_rebuilds_count = session.exec(successful_rebuilds_query).one()
+        return SuccessfulBuildsAndRebuilds(successful_builds_count, successful_rebuilds_count)

--- a/src/repror/internals/db.py
+++ b/src/repror/internals/db.py
@@ -347,10 +347,6 @@ def get_total_successful_builds_and_rebuilds(
             )
             .group_by(Build.recipe_name)
         )
-
-        all = session.exec(select_matching_builds).all()
-        print(all)
-
         subquery = select_matching_builds.subquery()
         # Query to get the total number of successful builds
         successful_builds_query = (

--- a/src/repror/internals/git.py
+++ b/src/repror/internals/git.py
@@ -120,7 +120,6 @@ def clone_repo(repo_url, clone_dir) -> int:
     ).return_code
 
 
-
 def clone_no_checkout(repo_url: str, clone_dir: Path) -> int:
     """Clone a repository without checking out the files."""
     return run_streaming_command(
@@ -152,7 +151,6 @@ def sparse_checkout_set(clone_dir: Path, sparse_path: Path) -> int:
         cwd=str(clone_dir),
         stream_type=StreamType.STDOUT,
     ).return_code
-
 
 
 def fetch_changes(clone_dir: Path) -> CompletedProcess:

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,0 +1,134 @@
+from datetime import datetime
+from sqlmodel import Session
+from repror.internals.db import (
+    Build,
+    BuildState,
+    Rebuild,
+    setup_local_db,
+    get_total_successful_builds_and_rebuilds,
+)
+
+# Define a couple of timestamps
+timestamp1 = datetime(2023, 1, 1, 12, 0, 0)
+timestamp2 = datetime(2023, 6, 1, 12, 0, 0)
+
+
+def seed_data(session: Session):
+    # Sample Build and Rebuild data
+    builds = [
+        Build(
+            id=1,
+            recipe_name="Recipe1",
+            state=BuildState.SUCCESS,
+            build_tool_hash="hash1",
+            recipe_hash="rhash1",
+            platform_name="Platform1",
+            platform_version="v1",
+            build_hash="bh1",
+            build_loc="loc1",
+            reason=None,
+            timestamp=timestamp1,
+            actions_url="url1",
+        ),
+        Build(
+            id=2,
+            recipe_name="Recipe2",
+            state=BuildState.SUCCESS,
+            build_tool_hash="hash2",
+            recipe_hash="rhash2",
+            platform_name="Platform2",
+            platform_version="v2",
+            build_hash="bh2",
+            build_loc="loc2",
+            reason=None,
+            timestamp=timestamp2,
+            actions_url="url2",
+        ),
+        Build(
+            id=3,
+            recipe_name="Recipe3",
+            state=BuildState.SUCCESS,
+            build_tool_hash="hash3",
+            recipe_hash="rhash3",
+            platform_name="Platform3",
+            platform_version="v3",
+            build_hash="bh3",
+            build_loc="loc3",
+            reason=None,
+            timestamp=timestamp2,
+            actions_url="url3",
+        ),
+        Build(
+            id=4,
+            recipe_name="Recipe4",
+            state=BuildState.SUCCESS,
+            build_tool_hash="hash4",
+            recipe_hash="rhash4",
+            platform_name="Platform4",
+            platform_version="v4",
+            build_hash="bh4",
+            build_loc="loc4",
+            reason=None,
+            timestamp=timestamp2,
+            actions_url="url4",
+        ),
+    ]
+
+    rebuilds = [
+        Rebuild(
+            id=1,
+            build_id=1,
+            state=BuildState.SUCCESS,
+            reason="Fix issue",
+            rebuild_hash="rbhash1",
+            timestamp=timestamp1,
+            actions_url="rebuild_url1",
+        ),
+        Rebuild(
+            id=2,
+            build_id=2,
+            state=BuildState.SUCCESS,
+            reason="Update dependencies",
+            rebuild_hash="rbhash2",
+            timestamp=timestamp2,
+            actions_url="rebuild_url2",
+        ),
+        Rebuild(
+            id=3,
+            build_id=3,
+            state=BuildState.SUCCESS,
+            reason="Security patch",
+            rebuild_hash="rbhash3",
+            timestamp=timestamp2,
+            actions_url="rebuild_url3",
+        ),
+        Rebuild(
+            id=4,
+            build_id=4,
+            state=BuildState.SUCCESS,
+            reason="Performance improvement",
+            rebuild_hash="rbhash4",
+            timestamp=timestamp2,
+            actions_url="rebuild_url4",
+        ),
+    ]
+
+    session.add_all(builds)
+    session.add_all(rebuilds)
+    session.commit()
+
+
+def test_aggregation():
+    sessionmaker = setup_local_db()
+    with sessionmaker() as session:
+        # Seed data
+        seed_data(session)
+        assert timestamp2 > timestamp1
+        result = get_total_successful_builds_and_rebuilds(timestamp1, None, session)
+        assert result.builds == 1, result.rebuilds == 1
+        print(result.builds, result.rebuilds)
+        result = get_total_successful_builds_and_rebuilds(
+            timestamp2, timestamp1, session
+        )
+        print(result.builds, result.rebuilds)
+        assert result.builds == 3, result.rebuilds == 3

--- a/tests/test_recipe_db.py
+++ b/tests/test_recipe_db.py
@@ -1,0 +1,14 @@
+from repror.internals.db import RemoteRecipe, get_total_unique_recipes, setup_local_db
+
+
+def test_recipe_db():
+    session_maker = setup_local_db()
+    with session_maker() as session:
+        # Insert some Recipes
+        recipe = RemoteRecipe(url="foobar", rev="asdfsdf", name="foo", content_hash="1234", path="bar", raw_config="raw")
+        recipe2 = RemoteRecipe(url="foobarz", rev="asdfsdf", name="foobar", content_hash="12345", path="bar", raw_config="raw")
+        session.add(recipe)
+        session.add(recipe2)
+        session.commit()
+
+    assert get_total_unique_recipes(session) == 2

--- a/tests/test_recipe_db.py
+++ b/tests/test_recipe_db.py
@@ -5,8 +5,22 @@ def test_recipe_db():
     session_maker = setup_local_db()
     with session_maker() as session:
         # Insert some Recipes
-        recipe = RemoteRecipe(url="foobar", rev="asdfsdf", name="foo", content_hash="1234", path="bar", raw_config="raw")
-        recipe2 = RemoteRecipe(url="foobarz", rev="asdfsdf", name="foobar", content_hash="12345", path="bar", raw_config="raw")
+        recipe = RemoteRecipe(
+            url="foobar",
+            rev="asdfsdf",
+            name="foo",
+            content_hash="1234",
+            path="bar",
+            raw_config="raw",
+        )
+        recipe2 = RemoteRecipe(
+            url="foobarz",
+            rev="asdfsdf",
+            name="foobar",
+            content_hash="12345",
+            path="bar",
+            raw_config="raw",
+        )
         session.add(recipe)
         session.add(recipe2)
         session.commit()


### PR DESCRIPTION
Aggregation of recipe statistics, I want to add functions to:

* Get total number of recipes
* Get succesfull builds/rebuilds near a given timestamp

During this PR I ran into the limitation of having a global session, making it hard to test.