### PR TITLE
feat: avoid flicker when loading page

### DIFF
--- a/src/repror/cli/templates/index.html.jinja
+++ b/src/repror/cli/templates/index.html.jinja
@@ -107,9 +107,9 @@
     });
 </script>
 
-<body class="bg-gray-100" x-data="modal()">
+<body class="bg-gray-100">
     <!-- Error messages modal -->
-    <div x-show="$store.modal.show" id="modal" class="modal fixed inset-0 bg-gray-800 bg-opacity-75 items-center justify-center z-10 ">
+    <div x-show="$store.modal.show" x-cloak id="modal" class="modal fixed inset-0 bg-gray-800 bg-opacity-75 items-center justify-center z-10 ">
         <div  class="fixed inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-300" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0">
             <div class="bg-white rounded-lg p-8 mx-auto" @click.outside="$store.modal.closeModal()">
                 <h2 class="text-2xl mb-4">Error Reason</h2>


### PR DESCRIPTION
The modal can flicker if the body is loaded before the alpine-js library is.

This avoids that.